### PR TITLE
Optimisations

### DIFF
--- a/AbstractSQLOptimiser.ometajs
+++ b/AbstractSQLOptimiser.ometajs
@@ -147,7 +147,8 @@ ometa AbstractSQLValidator {
 
 	Select =
 		[	'Select'
-			[	(	[	SelectField:field
+			[	(	[	&(anything string end)
+						SelectField:field
 						string:as
 					]
 					-> [field, as]
@@ -177,10 +178,11 @@ ometa AbstractSQLValidator {
 	Table =
 		[	'From'
 			(	~string
-				[	(	SelectQuery
+				[	&(anything string end)
+					(	SelectQuery
 					|	anything
 					):table
-					anything:as
+					string:as
 				]
 				-> [table, as]
 			|	SelectQuery

--- a/AbstractSQLOptimiser.ometajs
+++ b/AbstractSQLOptimiser.ometajs
@@ -1033,20 +1033,20 @@ export ometa AbstractSQLOptimiser <: AbstractSQLValidator {
 	Process =
 		:query
 		// Make sure we can at least do one valid pass.
-		(	AnyValue(query)
-		|	SelectQuery(query)
+		(	SelectQuery(query)
 		|	InsertQuery(query)
 		|	UpdateQuery(query)
 		|	DeleteQuery(query)
 		|	UpsertQuery(query)
+		|	AnyValue(query)
 		):query
 		(	Helped('disableMemoisation')
-			(	AnyValue(query)
-			|	SelectQuery(query)
+			(	SelectQuery(query)
 			|	InsertQuery(query)
 			|	UpdateQuery(query)
 			|	DeleteQuery(query)
 			|	UpsertQuery(query)
+			|	AnyValue(query)
 			):query
 		)*
 		-> query

--- a/AbstractSQLOptimiser.ometajs
+++ b/AbstractSQLOptimiser.ometajs
@@ -910,7 +910,7 @@ export ometa AbstractSQLOptimiser <: AbstractSQLValidator {
 		|	// Collapse nested ANDs.
 			[	'And'
 				{[]}:conditions
-				(	And:and
+				(	^And:and
 					{conditions.concat(and.slice(1))}:conditions
 					SetHelped
 				|	BooleanValue:bool

--- a/AbstractSQLOptimiser.ometajs
+++ b/AbstractSQLOptimiser.ometajs
@@ -165,7 +165,6 @@ ometa AbstractSQLValidator {
 	SelectField =
 			Count
 		|	AnyValue
-		|	Null
 	,
 
 	Count =

--- a/AbstractSQLRules2SQL.ometajs
+++ b/AbstractSQLRules2SQL.ometajs
@@ -192,8 +192,9 @@ export ometa AbstractSQLRules2SQL {
 		'Select'
 		[	end
 			{['1']}:fields
-		|	(	[	SelectField(indent):field
-					string:as
+		|	(	[	&(anything anything end)
+					SelectField(indent):field
+					anything:as
 				]
 				-> (field + ' AS "' + as + '"')
 			|	SelectField(indent)
@@ -221,14 +222,15 @@ export ometa AbstractSQLRules2SQL {
 		'From'
 		NestedIndent(indent):nestedindent
 		(	~string
-			[	(	SelectQuery(nestedindent):query
+			[	&(anything anything end)
+				(	SelectQuery(nestedindent):query
 					-> ('(' + nestedindent + query + indent + ')')
 				|	anything:table
 					-> ('"' + table + '"')
 				):from
-				anything:alias
+				anything:as
 			]
-			-> (from + ' AS "' + alias + '"')
+			-> (from + ' AS "' + as + '"')
 		|	SelectQuery(nestedindent):query
 			-> ('(' + nestedindent + query + indent + ')')
 		|	string:table


### PR DESCRIPTION
Adding the lookahead results in an ~64% gain in the abstract sql compilation time in the tests