### PR TITLE
 Add support for `IsDistinctFrom`/`IsNotDistinctFrom`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "@resin/sbvr-types": "^2.0.3",
     "@types/bluebird": "^3.5.27",
-    "@types/lodash": "^4.14.132",
-    "@types/node": "^8.10.48",
+    "@types/lodash": "^4.14.134",
+    "@types/node": "^8.10.49",
     "bluebird": "^3.5.5",
     "lodash": "^4.17.11"
   },
@@ -30,17 +30,17 @@
     "@resin/odata-to-abstract-sql": "3.0.1",
     "@resin/sbvr-parser": "0.2.2",
     "@types/chai": "^4.1.7",
-    "@types/mocha": "^5.2.6",
+    "@types/mocha": "^5.2.7",
     "chai": "^4.2.0",
     "coffeescript": "^1.12.7",
-    "husky": "^2.3.0",
-    "lint-staged": "^8.1.7",
+    "husky": "^2.4.1",
+    "lint-staged": "^8.2.1",
     "mocha": "^6.1.4",
-    "prettier": "^1.17.1",
+    "prettier": "^1.18.2",
     "require-npm4-to-publish": "^1.0.0",
     "resin-lint": "^2.0.1",
     "ts-node": "^7.0.1",
-    "typescript": "^3.5.1"
+    "typescript": "^3.5.2"
   },
   "husky": {
     "hooks": {

--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -25,7 +25,7 @@ export type DurationNode = [
 		hour?: Number;
 		minute?: Number;
 		second?: Number;
-	}
+	},
 ];
 
 // The extends array hacks in the node types are because otherwise we get issues with circular refs
@@ -172,7 +172,7 @@ export type SelectQueryNode = [
 		| OrderByNode
 		| LimitNode
 		| OffsetNode
-	>
+	>,
 ];
 export interface UnionQueryNode
 	extends VarArgNodeType<'UnionQuery', UnionQueryNode | SelectQueryNode> {}
@@ -191,18 +191,18 @@ export type TableNode = ['Table', string];
 export type WhereNode = ['Where', BooleanTypeNodes];
 export type GroupByNode = [
 	'GroupBy',
-	Array<['ASC' | 'DESC', FieldNode | ReferencedFieldNode]>
+	Array<['ASC' | 'DESC', FieldNode | ReferencedFieldNode]>,
 ];
 export type OrderByNode = [
 	'OrderBy',
-	...Array<['ASC' | 'DESC', FieldNode | ReferencedFieldNode]>
+	...Array<['ASC' | 'DESC', FieldNode | ReferencedFieldNode]>,
 ];
 export type LimitNode = ['Limit', NumberTypeNodes];
 export type OffsetNode = ['Offset', NumberTypeNodes];
 export type FieldsNode = ['Fields', string[]];
 export type ValuesNode = [
 	'Values',
-	SelectQueryNode | UnionQueryNode | ValuesNodeTypes[]
+	SelectQueryNode | UnionQueryNode | ValuesNodeTypes[],
 ];
 export type ValuesNodeTypes =
 	| 'Default'
@@ -516,7 +516,7 @@ const compileSchema = (
 	const fns: _.Dictionary<true> = {};
 	if (abstractSqlModel.functions) {
 		_.forEach(abstractSqlModel.functions, (fnDefinition, fnName) => {
-			if (engine !== 'postgres') {
+			if (engine !== Engines.postgres) {
 				throw new Error('Functions are only supported on postgres currently');
 			}
 			if (fnDefinition.language !== 'plpgsql') {
@@ -577,9 +577,7 @@ $$ LANGUAGE ${fnDefinition.language};`);
 		for (const { fieldName, references } of foreignKeys) {
 			const referencedTable = abstractSqlModel.tables[references.resourceName];
 			createSqlElements.push(
-				`FOREIGN KEY ("${fieldName}") REFERENCES "${referencedTable.name}" ("${
-					references.fieldName
-				}")`,
+				`FOREIGN KEY ("${fieldName}") REFERENCES "${referencedTable.name}" ("${references.fieldName}")`,
 			);
 		}
 		for (const index of table.indexes) {
@@ -683,7 +681,7 @@ CREATE TABLE ${ifNotExistsStr}"${table.name}" (
 		(rule): SqlRule => {
 			const ruleBodyNode = _.find(rule, { 0: 'Body' }) as [
 				'Body',
-				AbstractSqlQuery
+				AbstractSqlQuery,
 			];
 			if (ruleBodyNode == null || _.isString(ruleBodyNode)) {
 				throw new Error('Invalid rule');
@@ -694,7 +692,7 @@ CREATE TABLE ${ifNotExistsStr}"${table.name}" (
 			}
 			const ruleSENode = _.find(rule, { 0: 'StructuredEnglish' }) as [
 				'StructuredEnglish',
-				string
+				string,
 			];
 			if (ruleSENode == null) {
 				throw new Error('Invalid structured English');

--- a/src/AbstractSQLOptimiser.ts
+++ b/src/AbstractSQLOptimiser.ts
@@ -498,6 +498,8 @@ const typeRules: Dictionary<MatchFn> = {
 	LessThan: Comparison('LessThan'),
 	LessThanOrEqual: Comparison('LessThanOrEqual'),
 	Like: Comparison('Like'),
+	IsNotDistinctFrom: matchArgs('IsNotDistinctFrom', AnyValue, AnyValue),
+	IsDistinctFrom: matchArgs('IsDistinctFrom', AnyValue, AnyValue),
 	Add: MathOp('Add'),
 	Subtract: MathOp('Subtract'),
 	Multiply: MathOp('Multiply'),

--- a/src/AbstractSQLRules2SQL.ts
+++ b/src/AbstractSQLRules2SQL.ts
@@ -274,7 +274,7 @@ const ExtractNumericDatePart = (type: keyof typeof dateFormats): MatchFn => {
 	return (args, indent) => {
 		checkArgs(type, args, 1);
 		const date = DateValue(getAbstractSqlQuery(args, 0), indent);
-		if (engine === 'websql') {
+		if (engine === Engines.websql) {
 			return websqlDateFormats[type](date);
 		} else {
 			return dateFormats[type](date);
@@ -369,7 +369,7 @@ const MaybeAlias = (
 };
 
 const AddBind = (bind: Binding): string => {
-	if (engine === 'postgres') {
+	if (engine === Engines.postgres) {
 		if (bind[0] === 'Bind') {
 			const existingBindIndex = _.findIndex(fieldOrderings, existingBind =>
 				_.isEqual(bind, existingBind),
@@ -601,7 +601,7 @@ const typeRules: Dictionary<MatchFn> = {
 		checkArgs('AggregateJSON', args, 1);
 		args = getAbstractSqlQuery(args, 0);
 		checkArgs("AggregateJSON's argument", args, 2);
-		if (engine !== 'postgres') {
+		if (engine !== Engines.postgres) {
 			throw new SyntaxError('AggregateJSON not supported on: ' + engine);
 		}
 		const [table, field] = args;
@@ -636,9 +636,9 @@ const typeRules: Dictionary<MatchFn> = {
 	Totalseconds: (args, indent) => {
 		checkArgs('Totalseconds', args, 1);
 		const duration = DurationValue(getAbstractSqlQuery(args, 0), indent);
-		if (engine === 'postgres') {
+		if (engine === Engines.postgres) {
 			return `EXTRACT(EPOCH FROM ${duration})`;
-		} else if (engine === 'mysql') {
+		} else if (engine === Engines.mysql) {
 			return `(TIMESTAMPDIFF(MICROSECOND, FROM_UNIXTIME(0), FROM_UNIXTIME(0) + ${duration}) / 1000000)`;
 		} else {
 			throw new SyntaxError('TotalSeconds not supported on: ' + engine);
@@ -654,7 +654,7 @@ const typeRules: Dictionary<MatchFn> = {
 			}
 			return TextValue(arg, indent);
 		});
-		if (engine === 'mysql') {
+		if (engine === Engines.mysql) {
 			return 'CONCAT(' + comparators.join(', ') + ')';
 		} else {
 			return '(' + comparators.join(' || ') + ')';
@@ -670,7 +670,7 @@ const typeRules: Dictionary<MatchFn> = {
 	CharacterLength: (args, indent) => {
 		checkArgs('CharacterLength', args, 1);
 		const text = TextValue(getAbstractSqlQuery(args, 0), indent);
-		if (engine === 'mysql') {
+		if (engine === Engines.mysql) {
 			return `CHAR_LENGTH(${text})`;
 		} else {
 			return `LENGTH(${text})`;
@@ -680,7 +680,7 @@ const typeRules: Dictionary<MatchFn> = {
 		checkArgs('StrPos', args, 2);
 		const haystack = TextValue(getAbstractSqlQuery(args, 0), indent);
 		const needle = TextValue(getAbstractSqlQuery(args, 1), indent);
-		if (engine === 'postgres') {
+		if (engine === Engines.postgres) {
 			return `STRPOS(${haystack}, ${needle})`;
 		} else {
 			return `INSTR(${haystack}, ${needle})`;
@@ -703,7 +703,7 @@ const typeRules: Dictionary<MatchFn> = {
 		checkArgs('Right', args, 2);
 		const str = TextValue(getAbstractSqlQuery(args, 0), indent);
 		const n = NumericValue(getAbstractSqlQuery(args, 0), indent);
-		if (engine === 'websql') {
+		if (engine === Engines.websql) {
 			return `SUBSTRING(${str}, -${n})`;
 		} else {
 			return `RIGHT(${str}, ${n})`;
@@ -747,7 +747,7 @@ const typeRules: Dictionary<MatchFn> = {
 	ToTime: (args, indent) => {
 		checkArgs('ToTime', args, 1);
 		const date = DateValue(getAbstractSqlQuery(args, 0), indent);
-		if (engine === 'postgres') {
+		if (engine === Engines.postgres) {
 			return `CAST(${date} AS TIME)`;
 		} else {
 			return `TIME(${date})`;
@@ -840,7 +840,7 @@ const typeRules: Dictionary<MatchFn> = {
 	},
 	Duration: args => {
 		checkArgs('Duration', args, 1);
-		if (engine === 'websql') {
+		if (engine === Engines.websql) {
 			throw new SyntaxError('Durations not supported on: ' + engine);
 		}
 		// TODO: The abstract sql type should accommodate this
@@ -876,7 +876,7 @@ const typeRules: Dictionary<MatchFn> = {
 				minimumFractionDigits: 1,
 			}) +
 			"'" +
-			(engine === 'mysql' ? ' DAY_MICROSECOND' : '')
+			(engine === Engines.mysql ? ' DAY_MICROSECOND' : '')
 		);
 	},
 	Exists: (args, indent) => {

--- a/test/abstract-sql/is-distinct.ts
+++ b/test/abstract-sql/is-distinct.ts
@@ -1,0 +1,28 @@
+import { AbstractSqlQuery } from '../../src/AbstractSQLCompiler';
+
+// tslint:disable-next-line no-var-requires
+const test = require('./test') as (
+	query: AbstractSqlQuery,
+	cb: (
+		result: { query: string },
+		sqlEquals: (a: string, b: string) => void,
+	) => void,
+) => void;
+
+test(
+	['SelectQuery', ['Select', [['IsDistinctFrom', ['Number', 1], ['Null']]]]],
+	(result, sqlEquals) => {
+		it('should produce a valid is distinct from statement', () => {
+			sqlEquals(result.query, 'SELECT 1 IS DISTINCT FROM NULL');
+		});
+	},
+);
+
+test(
+	['SelectQuery', ['Select', [['IsNotDistinctFrom', ['Number', 1], ['Null']]]]],
+	(result, sqlEquals) => {
+		it('should produce a valid is not distinct from statement', () => {
+			sqlEquals(result.query, 'SELECT 1 IS NOT DISTINCT FROM NULL');
+		});
+	},
+);

--- a/test/abstract-sql/test.coffee
+++ b/test/abstract-sql/test.coffee
@@ -26,6 +26,7 @@ sqlEquals =
 runExpectation = (describe, engine, input, expectedBindings, body, expectation) ->
 	if !expectation?
 		if !body?
+			expectation = expectedBindings
 			expectedBindings = false
 		else
 			expectation = body
@@ -57,4 +58,3 @@ module.exports = bindRunExpectation('postgres')
 module.exports.postgres = bindRunExpectation('postgres')
 module.exports.mysql = bindRunExpectation('mysql')
 module.exports.websql = bindRunExpectation('websql')
-


### PR DESCRIPTION
This is split into two commits, one that has the prettier bump and `'postgres'`  -> `Engines.postgres` conversions, and the other that actually adds the new support, so you may want to review individually