### PR TITLE
Switch to a lookup table for finding existing bind var entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@resin/sbvr-types": "^2.0.3",
     "@types/bluebird": "^3.5.27",
     "@types/lodash": "^4.14.138",
-    "@types/node": "^8.10.53",
+    "@types/node": "^8.10.54",
     "bluebird": "^3.5.5",
     "lodash": "^4.17.15"
   },
@@ -29,7 +29,7 @@
     "@resin/odata-parser": "1.0.3",
     "@resin/odata-to-abstract-sql": "3.0.1",
     "@resin/sbvr-parser": "0.2.2",
-    "@types/chai": "^4.2.2",
+    "@types/chai": "^4.2.3",
     "@types/common-tags": "^1.8.0",
     "@types/mocha": "^5.2.7",
     "chai": "^4.2.0",
@@ -42,7 +42,7 @@
     "require-npm4-to-publish": "^1.0.0",
     "resin-lint": "^2.0.1",
     "ts-node": "^7.0.1",
-    "typescript": "^3.6.2"
+    "typescript": "^3.6.3"
   },
   "husky": {
     "hooks": {

--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -474,11 +474,11 @@ const getReferencedFields: EngineInstance['getReferencedFields'] = ruleBody => {
 
 const checkQuery = (query: AbstractSqlQuery): ModifiedFields | undefined => {
 	const queryType = query[0];
-	if (!_.includes(['InsertQuery', 'UpdateQuery', 'DeleteQuery'], queryType)) {
+	if (!['InsertQuery', 'UpdateQuery', 'DeleteQuery'].includes(queryType)) {
 		return;
 	}
 
-	const froms = _.filter(query, n => n[0] === 'From') as FromNode[];
+	const froms = query.filter(n => n[0] === 'From') as FromNode[];
 	if (froms.length !== 1) {
 		return;
 	}
@@ -508,7 +508,7 @@ const getModifiedFields: EngineInstance['getModifiedFields'] = (
 	abstractSqlQuery: AbstractSqlQuery,
 ) => {
 	if (_.isArray(abstractSqlQuery[0])) {
-		return _.map(abstractSqlQuery, checkQuery);
+		return abstractSqlQuery.map(checkQuery);
 	} else {
 		return checkQuery(abstractSqlQuery);
 	}
@@ -584,7 +584,7 @@ $$ LANGUAGE ${fnDefinition.language};`);
 					'"' + fieldName + '" ' + dataTypeGen(engine, field),
 				);
 				if (
-					_.includes(['ForeignKey', 'ConceptType'], dataType) &&
+					['ForeignKey', 'ConceptType'].includes(dataType) &&
 					references != null
 				) {
 					const referencedTable =
@@ -728,8 +728,7 @@ CREATE TABLE ${ifNotExistsStr}"${table.name}" (
 	createSchemaStatements.push(...alterSchemaStatements);
 	dropSchemaStatements = dropSchemaStatements.reverse();
 
-	const ruleStatements: SqlRule[] = _.map(
-		abstractSqlModel.rules,
+	const ruleStatements: SqlRule[] = abstractSqlModel.rules.map(
 		(rule): SqlRule => {
 			const ruleBodyNode = _.find(rule, { 0: 'Body' }) as [
 				'Body',

--- a/test/odata/stress.coffee
+++ b/test/odata/stress.coffee
@@ -8,6 +8,22 @@ filterBindsString = _.map(filterIDs, _.constant('?')).join(', ')
 filterBinds = _.map filterIDs, (n, i) ->
 	return ['Bind', i]
 
+filterString = "id in (#{filterIDs.join(', ')})"
+test '/pilot?$filter=' + filterString, 'GET', filterBinds, (result, sqlEquals) ->
+	it 'should select from pilot with a long IN clause', ->
+		sqlEquals result.query, '''
+			SELECT ''' + pilotFields + '\n' + '''
+			FROM "pilot"
+			WHERE "pilot"."id" IN (''' + filterBindsString + ')'
+
+filterString = "not(id in (#{filterIDs.join(', ')}))"
+test '/pilot?$filter=' + filterString, 'GET', filterBinds, (result, sqlEquals) ->
+	it 'should select from pilot with a long NOT IN clause', ->
+		sqlEquals result.query, '''
+			SELECT ''' + pilotFields + '\n' + '''
+			FROM "pilot"
+			WHERE "pilot"."id" NOT IN (''' + filterBindsString + ')'
+
 filterString = filterIDs.map((i) -> 'id eq ' + i).join(' or ')
 test '/pilot?$filter=' + filterString, 'GET', filterBinds, (result, sqlEquals) ->
 	it 'should select from pilot with a long IN clause', ->


### PR DESCRIPTION
This helps massively as the number of bind vars increases (200k was fine for abstract-sql-compiler), and actually moves the bottleneck to the odata parsing side instead: https://github.com/balena-io-modules/odata-to-abstract-sql/pull/46 

Change-type: patch