### PR TITLE
Only create functions if they don't already exist

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -593,12 +593,18 @@ const compileSchema = (
 			}
 			fns[fnName] = true;
 			createSchemaStatements.push(`\
-CREATE OR REPLACE FUNCTION "${fnName}"()
-RETURNS TRIGGER AS $$
+DO $$
 BEGIN
-	${fnDefinition.body}
+	PERFORM '"${fnName}"()'::regprocedure;
+EXCEPTION WHEN undefined_function THEN
+	CREATE FUNCTION "${fnName}"()
+	RETURNS TRIGGER AS $fn$
+	BEGIN
+		${fnDefinition.body}
+	END;
+	$fn$ LANGUAGE ${fnDefinition.language};
 END;
-$$ LANGUAGE ${fnDefinition.language};`);
+$$;`);
 			dropSchemaStatements.push(`DROP FUNCTION "${fnName}"();`);
 		});
 	}


### PR DESCRIPTION
This matches how we handle table/trigger creation and avoids issues
with running create schema statements concurrently

Change-type: patch