### PR TITLE
7.x major version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,34 +10,6 @@ buildSteps: &buildSteps
       command: npm test --loglevel warn
 
 jobs:
-  node-6:
-    docker:
-      - image: circleci/node:6
-    working_directory: ~/node-6
-    steps:
-    - checkout
-    - run:
-        name: Install
-        command: npm install --loglevel warn
-    - run:
-        name: Test
-        # Skip linting for node 6/8 as they cannot handle it and that will be checked by other versions
-        command: npm run test8 --loglevel warn
-
-  node-8:
-    docker:
-      - image: circleci/node:8
-    working_directory: ~/node-8
-    steps:
-    - checkout
-    - run:
-        name: Install
-        command: npm install --loglevel warn
-    - run:
-        name: Test
-        # Skip linting for node 6/8 as they cannot handle it and that will be checked by other versions
-        command: npm run test8 --loglevel warn
-
   node-10:
     docker:
       - image: circleci/node:10
@@ -60,8 +32,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - node-6
-      - node-8
       - node-10
       - node-12
       - node-14

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@resin/abstract-sql-compiler",
+  "name": "@balena/abstract-sql-compiler",
   "version": "6.13.6",
   "description": "A translator for abstract sql into sql.",
   "main": "out/AbstractSQLCompiler.js",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,8 @@
   "author": "",
   "dependencies": {
     "@resin/sbvr-types": "^2.0.9",
-    "@types/bluebird": "^3.5.31",
     "@types/lodash": "^4.14.152",
     "@types/node": "^10.17.24",
-    "bluebird": "^3.7.2",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "pretest": "npm run lint && npm run prepare",
     "test": "mocha",
-    "test8": "npm run-script prepare && mocha",
     "prepublish": "require-npm4-to-publish",
     "prepare": "tsc --project ./tsconfig.build.json",
     "lint:coffee": "balena-lint test/",
@@ -19,8 +18,8 @@
   "dependencies": {
     "@resin/sbvr-types": "^2.0.9",
     "@types/bluebird": "^3.5.31",
-    "@types/lodash": "^4.14.151",
-    "@types/node": "^8.10.60",
+    "@types/lodash": "^4.14.152",
+    "@types/node": "^10.17.24",
     "bluebird": "^3.7.2",
     "lodash": "^4.17.15"
   },
@@ -41,7 +40,7 @@
     "mocha": "^6.2.3",
     "require-npm4-to-publish": "^1.0.0",
     "ts-node": "^7.0.1",
-    "typescript": "^3.9.2"
+    "typescript": "^3.9.3"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "repository": "https://github.com/balena-io-modules/abstract-sql-compiler.git",
   "author": "",
   "dependencies": {
-    "@resin/sbvr-types": "^2.0.9",
+    "@balena/sbvr-types": "^3.0.0",
     "@types/lodash": "^4.14.152",
     "@types/node": "^10.17.24",
     "lodash": "^4.17.15"

--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -11,7 +11,7 @@ import {
 	SqlResult,
 } from './AbstractSQLRules2SQL';
 export { Binding, SqlResult } from './AbstractSQLRules2SQL';
-import sbvrTypes = require('@resin/sbvr-types');
+import sbvrTypes = require('@balena/sbvr-types');
 import * as _ from 'lodash';
 
 export type NullNode = ['Null'];

--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -12,7 +12,6 @@ import {
 } from './AbstractSQLRules2SQL';
 export { Binding, SqlResult } from './AbstractSQLRules2SQL';
 import sbvrTypes = require('@resin/sbvr-types');
-import * as Promise from 'bluebird';
 import * as _ from 'lodash';
 
 export type NullNode = ['Null'];
@@ -374,14 +373,17 @@ export interface EngineInstance {
 
 const validateTypes = _.mapValues(sbvrTypes, ({ validate }) => validate);
 
-const dataTypeValidate: EngineInstance['dataTypeValidate'] = (value, field) => {
+const dataTypeValidate: EngineInstance['dataTypeValidate'] = async (
+	value,
+	field,
+) => {
 	// In case one of the validation types throws an error.
 	const { dataType, required } = field;
 	const validateFn = validateTypes[dataType];
 	if (validateFn != null) {
 		return validateFn(value, required);
 	} else {
-		return Promise.reject(new Error('is an unsupported type: ' + dataType));
+		return new Error('is an unsupported type: ' + dataType);
 	}
 };
 

--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -27,104 +27,31 @@ export type DurationNode = [
 	},
 ];
 
-// The extends array hacks in the node types are because otherwise we get issues with circular refs
-export interface OneArgNodeType<T, X> extends Array<T | X> {
-	0: T;
-	1: X;
-	length: 2;
-}
-export interface TwoArgNodeType<T, X> extends Array<T | X> {
-	0: T;
-	1: X;
-	2: X;
-	length: 3;
-}
-export interface ThreeArgNodeType<T, X> extends Array<T | X> {
-	0: T;
-	1: X;
-	2: X;
-	3: X;
-	length: 4;
-}
-export interface OneTwoArgNodeType<T, X, Y>
-	extends Array<T | X | Y | undefined> {
-	0: T;
-	1: X;
-	2?: Y;
-	length: 2 | 3;
-}
-export interface VarArgNodeType<T, X> extends Array<T | X | undefined> {
-	0: T;
-	1?: X;
-	2?: X;
-	3?: X;
-	4?: X;
-	5?: X;
-	6?: X;
-	7?: X;
-	8?: X;
-	9?: X;
-	10?: X;
-	11?: X;
-	12?: X;
-	13?: X;
-	14?: X;
-	15?: X;
-	16?: X;
-	17?: X;
-	18?: X;
-	19?: X;
-	20?: X;
-	21?: X;
-}
-export interface TwoVarArgNodeType<T, X, Y>
-	extends Array<T | X | Y | undefined> {
-	0: T;
-	1?: X;
-	2?: Y;
-	3?: Y;
-	4?: Y;
-	5?: Y;
-	6?: Y;
-	7?: Y;
-	8?: Y;
-	9?: Y;
-	10?: Y;
-	11?: Y;
-	12?: Y;
-	13?: Y;
-	14?: Y;
-	15?: Y;
-	16?: Y;
-	17?: Y;
-	18?: Y;
-	19?: Y;
-	20?: Y;
-	21?: Y;
-}
-
 export type BooleanNode = ['Boolean', boolean];
-export interface EqualsNode extends TwoArgNodeType<'Equals', AbstractSqlType> {}
-export interface NotEqualsNode
-	extends TwoArgNodeType<'NotEquals', AbstractSqlType> {}
-export interface GreaterThanNode
-	extends TwoArgNodeType<'GreaterThan', AbstractSqlType> {}
-export interface GreaterThanOrEqualNode
-	extends TwoArgNodeType<'GreaterThanOrEqual', AbstractSqlType> {}
-export interface LessThanNode
-	extends TwoArgNodeType<'LessThan', AbstractSqlType> {}
-export interface LessThanOrEqualNode
-	extends TwoArgNodeType<'LessThanOrEqual', AbstractSqlType> {}
-export interface InNode
-	extends TwoVarArgNodeType<
-		'In',
-		FieldNode | ReferencedFieldNode,
-		AbstractSqlType
-	> {}
-export interface ExistsNode extends OneArgNodeType<'Exists', AbstractSqlType> {}
-export interface NotNode extends OneArgNodeType<'Not', BooleanTypeNodes> {}
-export interface AndNode extends VarArgNodeType<'And', BooleanTypeNodes> {}
-export interface OrNode extends VarArgNodeType<'Or', BooleanTypeNodes> {}
+export type EqualsNode = ['Equals', AbstractSqlType, AbstractSqlType];
+export type NotEqualsNode = ['NotEquals', AbstractSqlType, AbstractSqlType];
+export type GreaterThanNode = ['GreaterThan', AbstractSqlType, AbstractSqlType];
+export type GreaterThanOrEqualNode = [
+	'GreaterThanOrEqual',
+	AbstractSqlType,
+	AbstractSqlType,
+];
+export type LessThanNode = ['LessThan', AbstractSqlType, AbstractSqlType];
+export type LessThanOrEqualNode = [
+	'LessThanOrEqual',
+	AbstractSqlType,
+	AbstractSqlType,
+];
+export type InNode = [
+	'In',
+	FieldNode | ReferencedFieldNode,
+	AbstractSqlType,
+	...AbstractSqlType[]
+];
+export type ExistsNode = ['Exists', AbstractSqlType];
+export type NotNode = ['Not', BooleanTypeNodes];
+export type AndNode = ['And', ...BooleanTypeNodes[]];
+export type OrNode = ['Or', ...BooleanTypeNodes[]];
 export type BooleanTypeNodes =
 	| BooleanNode
 	| EqualsNode
@@ -154,24 +81,30 @@ export type NumberTypeNodes =
 export type FieldNode = ['Field', string];
 export type ReferencedFieldNode = ['ReferencedField', string, string];
 export type BindNode = ['Bind', string, string?];
-export interface CastNode
-	extends TwoVarArgNodeType<'Cast', AbstractSqlType, string> {}
-export interface CoalesceNode
-	extends TwoVarArgNodeType<'Coalesce', UnknownTypeNodes, UnknownTypeNodes> {}
+export type CastNode = ['Cast', AbstractSqlType, string];
+export type CoalesceNode = [
+	'Cast',
+	UnknownTypeNodes,
+	UnknownTypeNodes,
+	...UnknownTypeNodes[]
+];
 export type UnknownTypeNodes =
 	| FieldNode
 	| ReferencedFieldNode
 	| BindNode
 	| CastNode
 	| CoalesceNode
-	| AbstractSqlQuery;
+	| UnknownNode;
 
 export type TextNode = ['Text', string];
-export interface ConcatenateNode
-	extends VarArgNodeType<'Concatenate', TextTypeNodes> {}
+export type ConcatenateNode = ['Concatenate', ...TextTypeNodes[]];
 export type LikeNode = ['Like', '*'];
-export interface ReplaceNode
-	extends ThreeArgNodeType<'Replace', TextTypeNodes> {}
+export type ReplaceNode = [
+	'Replace',
+	TextTypeNodes,
+	TextTypeNodes,
+	TextTypeNodes,
+];
 export type TextTypeNodes =
 	| ConcatenateNode
 	| LikeNode
@@ -195,8 +128,10 @@ export type SelectQueryNode = [
 		| OffsetNode
 	>
 ];
-export interface UnionQueryNode
-	extends VarArgNodeType<'UnionQuery', UnionQueryNode | SelectQueryNode> {}
+export type UnionQueryNode = [
+	'UnionQuery',
+	...Array<UnionQueryNode | SelectQueryNode>
+];
 
 type FromTypeNodes =
 	| SelectQueryNode
@@ -204,19 +139,13 @@ type FromTypeNodes =
 	| TableNode
 	| AliasNode<SelectQueryNode | UnionQueryNode | TableNode>;
 
-export interface SelectNode
-	extends OneArgNodeType<'Select', AbstractSqlType[]> {}
-export interface FromNode extends OneArgNodeType<'From', FromTypeNodes> {}
-export interface InnerJoinNode
-	extends OneTwoArgNodeType<'Join', FromTypeNodes, OnNode> {}
-export interface LeftJoinNode
-	extends OneTwoArgNodeType<'LeftJoin', FromTypeNodes, OnNode> {}
-export interface RightJoinNode
-	extends OneTwoArgNodeType<'RightJoin', FromTypeNodes, OnNode> {}
-export interface FullJoinNode
-	extends OneTwoArgNodeType<'FullJoin', FromTypeNodes, OnNode> {}
-export interface CrossJoinNode
-	extends OneArgNodeType<'CrossJoin', FromTypeNodes> {}
+export type SelectNode = ['Select', AbstractSqlType[]];
+export type FromNode = ['From', FromTypeNodes];
+export type InnerJoinNode = ['Join', FromTypeNodes, OnNode?];
+export type LeftJoinNode = ['LeftJoin', FromTypeNodes, OnNode?];
+export type RightJoinNode = ['RightJoin', FromTypeNodes, OnNode?];
+export type FullJoinNode = ['FullJoin', FromTypeNodes, OnNode?];
+export type CrossJoinNode = ['CrossJoin', FromTypeNodes];
 export type OnNode = ['On', BooleanTypeNodes];
 export type TableNode = ['Table', string];
 export type WhereNode = ['Where', BooleanTypeNodes];
@@ -253,10 +182,11 @@ export type AbstractSqlType =
 	| TextTypeNodes
 	| UnknownTypeNodes
 	| DurationNode
-	| AbstractSqlQuery
 	| SelectQueryNode
 	| SelectNode
-	| ValuesNode;
+	| ValuesNode
+	| UnknownNode;
+export type UnknownNode = AbstractSqlQuery;
 export interface AbstractSqlQuery extends Array<AbstractSqlType> {
 	0: string;
 }

--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -133,11 +133,23 @@ export type UnionQueryNode = [
 	...Array<UnionQueryNode | SelectQueryNode>
 ];
 
+/**
+ * This interface allows adding to the valid set of FromTypeNodes using interface merging, eg
+ * declare module '@balena/abstract-sql-compiler' {
+ * 	interface FromTypeNode {
+ * 		MyNode: MyNode;
+ * 	}
+ * }
+ */
+export interface FromTypeNode {
+	SelectQueryNode: SelectQueryNode;
+	UnionQueryNode: UnionQueryNode;
+	TableNode: TableNode;
+}
+
 type FromTypeNodes =
-	| SelectQueryNode
-	| UnionQueryNode
-	| TableNode
-	| AliasNode<SelectQueryNode | UnionQueryNode | TableNode>;
+	| FromTypeNode[keyof FromTypeNode]
+	| AliasNode<FromTypeNode[keyof FromTypeNode]>;
 
 export type SelectNode = ['Select', AbstractSqlType[]];
 export type FromNode = ['From', FromTypeNodes];

--- a/src/AbstractSQLRules2SQL.ts
+++ b/src/AbstractSQLRules2SQL.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 
-import sbvrTypes = require('@resin/sbvr-types');
+import sbvrTypes = require('@balena/sbvr-types');
 
 import { Dictionary } from 'lodash';
 import {

--- a/test/odata/test.coffee
+++ b/test/odata/test.coffee
@@ -9,8 +9,8 @@ expect = require('chai').expect
 _ = require('lodash')
 
 generateClientModel = (input) ->
-	sbvrTypes = require '@resin/sbvr-types'
-	typeVocab = fs.readFileSync(require.resolve('@resin/sbvr-types/Type.sbvr'), 'utf8')
+	sbvrTypes = require '@balena/sbvr-types'
+	typeVocab = fs.readFileSync(require.resolve('@balena/sbvr-types/Type.sbvr'), 'utf8')
 
 	SBVRParser = require('@balena/sbvr-parser').SBVRParser.createInstance()
 	SBVRParser.enableReusingMemoizations(SBVRParser._sideEffectingRules)

--- a/test/sbvr/pilots.coffee
+++ b/test/sbvr/pilots.coffee
@@ -1,5 +1,5 @@
 # coffeelint: disable=max_line_length
-typeVocab = require('fs').readFileSync(require.resolve('@resin/sbvr-types/Type.sbvr'))
+typeVocab = require('fs').readFileSync(require.resolve('@balena/sbvr-types/Type.sbvr'))
 test = require('./test')(typeVocab)
 
 modifiedAtTrigger = (tableName) ->

--- a/test/sbvr/test.coffee
+++ b/test/sbvr/test.coffee
@@ -1,5 +1,5 @@
 _ = require 'lodash'
-sbvrTypes = require '@resin/sbvr-types'
+sbvrTypes = require '@balena/sbvr-types'
 
 expect = require('chai').expect
 AbstractSQLCompiler = require('../..')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,7 @@
 		"strictNullChecks": true,
 		"declaration": true,
 		"skipLibCheck": true,
-		"lib": [
-			"es2016"
-		],
+		"target": "es2018",
 		"outDir": "out"
 	},
 	"include": [


### PR DESCRIPTION
* Drop support for node 6/8
* Update tsconfig to target es2018
* Convert all returned promises to native promises instead of bluebird
* Update to @balena/sbvr-types 3.0.0
* Improve typings - this is https://github.com/balena-io-modules/abstract-sql-compiler/pull/79 but brought into this as it is a major change in terms of typings
* Rename to @balena/abstract-sql-compiler