### PR TITLE
Remove accidental `necessity` from the `AbstractSqlField` types

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -213,7 +213,6 @@ export interface AbstractSqlField {
 		fieldName: string;
 	};
 	defaultValue?: string;
-	necessity: boolean;
 	computed?: AbstractSqlQuery;
 	checks?: BooleanTypeNodes[];
 }


### PR DESCRIPTION
Change-type: patch