### PR TITLE
Add a `getRuleReferencedFields` which is tailored for rules

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -281,6 +281,7 @@ export interface SqlRule {
 	bindings: Binding[];
 	structuredEnglish: string;
 	referencedFields?: ReferencedFields;
+	ruleReferencedFields?: RuleReferencedFields;
 }
 /**
  * The RelationshipMapping can either describe a relationship to another term, or
@@ -997,12 +998,19 @@ CREATE TABLE ${ifNotExistsStr}"${table.name}" (
 			} catch (e) {
 				console.warn('Error fetching referenced fields', e);
 			}
+			let ruleReferencedFields: RuleReferencedFields | undefined;
+			try {
+				ruleReferencedFields = getRuleReferencedFields(ruleBody);
+			} catch (e) {
+				console.warn('Error fetching rule referenced fields', e);
+			}
 
 			return {
 				structuredEnglish: ruleSE,
 				sql: ruleSQL,
 				bindings: ruleBindings,
 				referencedFields,
+				ruleReferencedFields,
 			};
 		},
 	);

--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -338,6 +338,7 @@ export interface SqlModel {
 
 export interface ModifiedFields {
 	table: string;
+	action: keyof RuleReferencedFields[string];
 	fields?: string[];
 }
 
@@ -626,15 +627,18 @@ const checkQuery = (query: AbstractSqlQuery): ModifiedFields | undefined => {
 		return;
 	}
 
-	if (['InsertQuery', 'DeleteQuery'].includes(queryType)) {
-		return { table: tableName };
+	if (queryType === 'InsertQuery') {
+		return { table: tableName, action: 'create' };
+	}
+	if (queryType === 'DeleteQuery') {
+		return { table: tableName, action: 'delete' };
 	}
 
 	const fields = _<FieldsNode | AbstractSqlType>(query)
 		.filter((v): v is FieldsNode => v != null && v[0] === 'Fields')
 		.flatMap((v) => v[1])
 		.value();
-	return { table: tableName, fields };
+	return { table: tableName, action: 'update', fields };
 };
 const getModifiedFields: EngineInstance['getModifiedFields'] = (
 	abstractSqlQuery: AbstractSqlQuery,

--- a/test/abstract-sql/get-rule-referenced-fields.ts
+++ b/test/abstract-sql/get-rule-referenced-fields.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import * as AbstractSqlCompiler from '../../src/AbstractSQLCompiler';
+
+describe('getReferencedFields', () => {
+	it('should work with selected fields', () => {
+		expect(
+			AbstractSqlCompiler.postgres.getRuleReferencedFields([
+				'Not',
+				[
+					'Exists',
+					[
+						'SelectQuery',
+						['Select', []],
+						['From', ['test', 'test.0']],
+						[
+							'Where',
+							[
+								'Not',
+								[
+									'And',
+									[
+										'LessThan',
+										['Integer', 0],
+										['ReferencedField', 'test.0', 'id'],
+									],
+									['Exists', ['ReferencedField', 'test.0', 'id']],
+								],
+							],
+						],
+					],
+				],
+			] as AbstractSqlCompiler.AbstractSqlQuery),
+		).to.deep.equal({
+			test: {
+				create: ['id'],
+				update: ['id'],
+				delete: [],
+			},
+		});
+	});
+});


### PR DESCRIPTION
This works on the assumption that it is a rule query that should always
return true and allows ignoring more modification cases where they
cannot change the result from true to false

Change-type: minor