### PR TITLE
Remove now unnecessary hack for casting SERIAL types

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,16 +17,16 @@
   "dependencies": {
     "@balena/sbvr-types": "^3.4.2",
     "@types/lodash": "^4.14.168",
-    "@types/node": "^10.17.55",
+    "@types/node": "^10.17.59",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@balena/lf-to-abstract-sql": "^4.2.1",
-    "@balena/lint": "^5.4.1",
+    "@balena/lint": "^5.4.2",
     "@balena/odata-parser": "^2.2.3",
     "@balena/sbvr-parser": "^1.2.2",
     "@resin/odata-to-abstract-sql": "^3.3.0",
-    "@types/chai": "^4.2.15",
+    "@types/chai": "^4.2.17",
     "@types/common-tags": "^1.8.0",
     "@types/mocha": "^8.2.2",
     "chai": "^4.3.4",
@@ -36,7 +36,7 @@
     "mocha": "^8.3.2",
     "require-npm4-to-publish": "^1.0.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.4"
   },
   "husky": {
     "hooks": {

--- a/src/AbstractSQLRules2SQL.ts
+++ b/src/AbstractSQLRules2SQL.ts
@@ -744,10 +744,6 @@ const typeRules: Dictionary<MatchFn> = {
 		const dbType = sbvrTypes[typeName].types[engine];
 		if (typeof dbType === 'function') {
 			type = dbType.castType;
-		} else if (dbType.toUpperCase() === 'SERIAL') {
-			// HACK: SERIAL type in postgres is really an INTEGER with automatic sequence,
-			// so it's not actually possible to cast to SERIAL, instead you have to cast to INTEGER.
-			type = 'INTEGER';
 		} else {
 			type = dbType;
 		}


### PR DESCRIPTION
This became unnecessary when @balena/sbvr-types added the concept of
cast types since that now specifies how to cast a SERIAL type

Change-type: patch