### PR TITLE
Revert "Remove now unnecessary hack for casting SERIAL types"

### DIFF
--- a/src/AbstractSQLRules2SQL.ts
+++ b/src/AbstractSQLRules2SQL.ts
@@ -744,6 +744,10 @@ const typeRules: Dictionary<MatchFn> = {
 		const dbType = sbvrTypes[typeName].types[engine];
 		if (typeof dbType === 'function') {
 			type = dbType.castType;
+		} else if (dbType.toUpperCase() === 'SERIAL') {
+			// HACK: SERIAL type in postgres is really an INTEGER with automatic sequence,
+			// so it's not actually possible to cast to SERIAL, instead you have to cast to INTEGER.
+			type = 'INTEGER';
 		} else {
 			type = dbType;
 		}


### PR DESCRIPTION
This reverts commit 187bc075d237a2ced731d0a026ca25aa3e0f5540.

Change-type: patch