### PR TITLE
Supprt date_trunc postgres date function

### DIFF
--- a/src/AbstractSQLOptimiser.ts
+++ b/src/AbstractSQLOptimiser.ts
@@ -650,6 +650,7 @@ const typeRules: Dictionary<MatchFn> = {
 	Floor: matchArgs('Floor', NumericValue),
 	Ceiling: matchArgs('Ceiling', NumericValue),
 	ToDate: matchArgs('ToDate', DateValue),
+	DateTrunc: matchArgs('DateTrunc', TextValue, DateValue),
 	ToTime: matchArgs('ToTime', DateValue),
 	Coalesce: (args) => {
 		checkMinArgs('Coalesce', args, 2);

--- a/src/AbstractSQLRules2SQL.ts
+++ b/src/AbstractSQLRules2SQL.ts
@@ -178,7 +178,8 @@ export const isDateValue = (
 		type === 'ToDate' ||
 		type === 'ToTime' ||
 		type === 'CurrentTimestamp' ||
-		type === 'CurrentDate'
+		type === 'CurrentDate' ||
+		type === 'DateTrunc'
 	);
 };
 const DateValue = MatchValue(isDateValue);
@@ -938,6 +939,15 @@ const typeRules: Dictionary<MatchFn> = {
 		checkArgs('ToDate', args, 1);
 		const date = DateValue(getAbstractSqlQuery(args, 0), indent);
 		return `DATE(${date})`;
+	},
+	DateTrunc: (args, indent) => {
+		if (engine !== Engines.postgres) {
+			throw new SyntaxError('DateTrunc is not supported on: ' + engine);
+		}
+		checkArgs('DateTrunc', args, 2);
+		const precision = TextValue(getAbstractSqlQuery(args, 0), indent);
+		const date = DateValue(getAbstractSqlQuery(args, 1), indent);
+		return `DATE_TRUNC(${precision}, ${date})`;
 	},
 	ToTime: (args, indent) => {
 		checkArgs('ToTime', args, 1);

--- a/test/abstract-sql/functions_wrapper.ts
+++ b/test/abstract-sql/functions_wrapper.ts
@@ -1,0 +1,51 @@
+import { stripIndent } from 'common-tags';
+import { AbstractSqlQuery } from '../../src/AbstractSQLCompiler';
+
+type TestCb = (
+	result: { query: string },
+	sqlEquals: (a: string, b: string) => void,
+) => void;
+// tslint:disable-next-line no-var-requires
+const test = require('./test') as (
+	query: AbstractSqlQuery,
+	binds: any[][] | TestCb,
+	cb?: TestCb,
+) => void;
+
+describe('Date trunc function on ReferencedField', () => {
+	test(
+		[
+			'SelectQuery',
+			['Select', []],
+			['From', ['Table', 'table']],
+			[
+				'Where',
+				[
+					'GreaterThan',
+					[
+						'DateTrunc',
+						['Text', 'milliseconds'],
+						['ReferencedField', 'table', 'created at'],
+					],
+					['Bind', 0],
+				],
+			],
+		],
+		[
+			['Text', 'milliseconds'],
+			['Bind', 0],
+		],
+		(result, sqlEquals) => {
+			it('Generate a postgresql DATE_TRUNC query for referenced field with milliseconds resoluton and binding', () => {
+				sqlEquals(
+					result.query,
+					stripIndent`
+						SELECT 1
+						FROM "table"
+						WHERE DATE_TRUNC($1, "table"."created at") > $2
+					`,
+				);
+			});
+		},
+	);
+});


### PR DESCRIPTION
Supprt date_trunc postgres date function
for DateValue

Change-type: patch
Signed-off-by: fisehara harald@balena.io
