### PR TITLE
Support for non postgres db engines

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -93,6 +93,8 @@ export type NumberTypeNodes =
 
 export type FieldNode = ['Field', string];
 export type ReferencedFieldNode = ['ReferencedField', string, string];
+export type DateTruncNode = ['DateTrunc', TextTypeNodes, DateTypeNodes];
+export type DateTypeNodes = DateNode | DateTruncNode;
 export type BindNode = ['Bind', number | string] | ['Bind', string, string];
 export type CastNode = ['Cast', AbstractSqlType, string];
 export type CoalesceNode = [


### PR DESCRIPTION
FunctionWrapper type for ReferencedField

Change-type: patch
Signed-off-by: fisehara <harald@balena.io>