### PR TITLE
Add informative reference dataType to schema tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@balena/lf-to-abstract-sql": "^4.3.0",
+    "@balena/lf-to-abstract-sql": "^4.5.0",
     "@balena/lint": "^6.1.1",
     "@balena/odata-parser": "^2.2.8",
-    "@balena/sbvr-parser": "^1.2.5",
+    "@balena/sbvr-parser": "^1.4.0",
     "@resin/odata-to-abstract-sql": "^3.3.0",
     "@types/chai": "^4.2.21",
     "@types/common-tags": "^1.8.1",

--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -248,6 +248,7 @@ export interface AbstractSqlField {
 	references?: {
 		resourceName: string;
 		fieldName: string;
+		type?: string;
 	};
 	defaultValue?: string;
 	computed?: AbstractSqlQuery;
@@ -648,7 +649,9 @@ BEGIN
 END;
 $$;`);
 					} else {
-						foreignKeys.push(fkDefinition);
+						if (references.type !== 'informative') {
+							foreignKeys.push(fkDefinition);
+						}
 						depends.push(references.resourceName);
 						hasDependants[references.resourceName] = true;
 					}

--- a/test/abstract-sql/schema-informative-reference.ts
+++ b/test/abstract-sql/schema-informative-reference.ts
@@ -1,0 +1,416 @@
+import * as AbstractSQLCompiler from '../..';
+import { expect } from 'chai';
+
+describe('generate informative reference schema', () => {
+	it('reference type informative produces just a column without foreign key / constraint', () => {
+		expect(
+			AbstractSQLCompiler.postgres.compileSchema({
+				tables: {
+					term: {
+						fields: [
+							{
+								dataType: 'Date Time',
+								fieldName: 'created at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Date Time',
+								fieldName: 'modified at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Serial',
+								fieldName: 'id',
+								required: true,
+								index: 'PRIMARY KEY',
+							},
+						],
+						primitive: false,
+						name: 'term',
+						indexes: [],
+						idField: 'id',
+						resourceName: 'term',
+					},
+					'term history': {
+						fields: [
+							{
+								dataType: 'Date Time',
+								fieldName: 'created at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Date Time',
+								fieldName: 'modified at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Serial',
+								fieldName: 'id',
+								required: true,
+								index: 'PRIMARY KEY',
+							},
+							{
+								dataType: 'ForeignKey',
+								fieldName: 'references-term',
+								required: true,
+								references: {
+									resourceName: 'term',
+									fieldName: 'id',
+									type: 'informative',
+								},
+							},
+						],
+						primitive: false,
+						name: 'term history',
+						indexes: [],
+						idField: 'id',
+						resourceName: 'term history',
+					},
+				},
+				relationships: {},
+				rules: [],
+				synonyms: {},
+			}),
+		)
+			.to.have.property('createSchema')
+			.that.deep.equals([
+				`\
+CREATE TABLE IF NOT EXISTS "term" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+);`,
+				`\
+CREATE TABLE IF NOT EXISTS "term history" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+,	"references-term" INTEGER NOT NULL
+);`,
+			]);
+	});
+
+	it('reference type informative produces just a column without foreign key / constraint - mixed mode', () => {
+		expect(
+			AbstractSQLCompiler.postgres.compileSchema({
+				tables: {
+					term: {
+						fields: [
+							{
+								dataType: 'Date Time',
+								fieldName: 'created at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Date Time',
+								fieldName: 'modified at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Serial',
+								fieldName: 'id',
+								required: true,
+								index: 'PRIMARY KEY',
+							},
+						],
+						primitive: false,
+						name: 'term',
+						indexes: [],
+						idField: 'id',
+						resourceName: 'term',
+					},
+					termterm: {
+						fields: [
+							{
+								dataType: 'Date Time',
+								fieldName: 'created at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Date Time',
+								fieldName: 'modified at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Serial',
+								fieldName: 'id',
+								required: true,
+								index: 'PRIMARY KEY',
+							},
+						],
+						primitive: false,
+						name: 'termterm',
+						indexes: [],
+						idField: 'id',
+						resourceName: 'termterm',
+					},
+					'term history': {
+						fields: [
+							{
+								dataType: 'Date Time',
+								fieldName: 'created at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Date Time',
+								fieldName: 'modified at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Serial',
+								fieldName: 'id',
+								required: true,
+								index: 'PRIMARY KEY',
+							},
+							{
+								dataType: 'ForeignKey',
+								fieldName: 'references-term',
+								required: true,
+								references: {
+									resourceName: 'term',
+									fieldName: 'id',
+									type: 'informative',
+								},
+							},
+							{
+								dataType: 'ForeignKey',
+								fieldName: 'references-termterm',
+								required: true,
+								references: {
+									resourceName: 'termterm',
+									fieldName: 'id',
+								},
+							},
+						],
+						primitive: false,
+						name: 'term history',
+						indexes: [],
+						idField: 'id',
+						resourceName: 'term history',
+					},
+				},
+				relationships: {},
+				rules: [],
+				synonyms: {},
+			}),
+		)
+			.to.have.property('createSchema')
+			.that.deep.equals([
+				`\
+CREATE TABLE IF NOT EXISTS "term" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+);`,
+				`\
+CREATE TABLE IF NOT EXISTS "termterm" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+);`,
+				`\
+CREATE TABLE IF NOT EXISTS "term history" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+,	"references-term" INTEGER NOT NULL
+,	"references-termterm" INTEGER NOT NULL
+,	FOREIGN KEY ("references-termterm") REFERENCES "termterm" ("id")
+);`,
+			]);
+	});
+	it('reference type strict produces a column foreign key / constraint', () => {
+		expect(
+			AbstractSQLCompiler.postgres.compileSchema({
+				tables: {
+					term: {
+						fields: [
+							{
+								dataType: 'Date Time',
+								fieldName: 'created at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Date Time',
+								fieldName: 'modified at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Serial',
+								fieldName: 'id',
+								required: true,
+								index: 'PRIMARY KEY',
+							},
+						],
+						primitive: false,
+						name: 'term',
+						indexes: [],
+						idField: 'id',
+						resourceName: 'term',
+					},
+					'term history': {
+						fields: [
+							{
+								dataType: 'Date Time',
+								fieldName: 'created at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Date Time',
+								fieldName: 'modified at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Serial',
+								fieldName: 'id',
+								required: true,
+								index: 'PRIMARY KEY',
+							},
+							{
+								dataType: 'ForeignKey',
+								fieldName: 'references-term',
+								required: true,
+								references: {
+									resourceName: 'term',
+									fieldName: 'id',
+									type: 'strict',
+								},
+							},
+						],
+						primitive: false,
+						name: 'term history',
+						indexes: [],
+						idField: 'id',
+						resourceName: 'term history',
+					},
+				},
+				relationships: {},
+				rules: [],
+				synonyms: {},
+			}),
+		)
+			.to.have.property('createSchema')
+			.that.deep.equals([
+				`\
+CREATE TABLE IF NOT EXISTS "term" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+);`,
+				`\
+CREATE TABLE IF NOT EXISTS "term history" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+,	"references-term" INTEGER NOT NULL
+,	FOREIGN KEY ("references-term") REFERENCES "term" ("id")
+);`,
+			]);
+	});
+
+	it('reference type undefined produces a column foreign key / constraint', () => {
+		expect(
+			AbstractSQLCompiler.postgres.compileSchema({
+				tables: {
+					term: {
+						fields: [
+							{
+								dataType: 'Date Time',
+								fieldName: 'created at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Date Time',
+								fieldName: 'modified at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Serial',
+								fieldName: 'id',
+								required: true,
+								index: 'PRIMARY KEY',
+							},
+						],
+						primitive: false,
+						name: 'term',
+						indexes: [],
+						idField: 'id',
+						resourceName: 'term',
+					},
+					'term history': {
+						fields: [
+							{
+								dataType: 'Date Time',
+								fieldName: 'created at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Date Time',
+								fieldName: 'modified at',
+								required: true,
+								defaultValue: 'CURRENT_TIMESTAMP',
+							},
+							{
+								dataType: 'Serial',
+								fieldName: 'id',
+								required: true,
+								index: 'PRIMARY KEY',
+							},
+							{
+								dataType: 'ForeignKey',
+								fieldName: 'references-term',
+								required: true,
+								references: {
+									resourceName: 'term',
+									fieldName: 'id',
+								},
+							},
+						],
+						primitive: false,
+						name: 'term history',
+						indexes: [],
+						idField: 'id',
+						resourceName: 'term history',
+					},
+				},
+				relationships: {},
+				rules: [],
+				synonyms: {},
+			}),
+		)
+			.to.have.property('createSchema')
+			.that.deep.equals([
+				`\
+CREATE TABLE IF NOT EXISTS "term" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+);`,
+				`\
+CREATE TABLE IF NOT EXISTS "term history" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+,	"references-term" INTEGER NOT NULL
+,	FOREIGN KEY ("references-term") REFERENCES "term" ("id")
+);`,
+			]);
+	});
+});

--- a/test/sbvr/reference-type.js
+++ b/test/sbvr/reference-type.js
@@ -1,0 +1,206 @@
+const typeVocab = require('fs').readFileSync(
+	require.resolve('@balena/sbvr-types/Type.sbvr'),
+);
+const modifiedAtTrigger = (tableName) => `\
+DO
+$$
+BEGIN
+IF NOT EXISTS(
+	SELECT 1
+	FROM "information_schema"."triggers"
+	WHERE "event_object_table" = '${tableName}'
+	AND "trigger_name" = '${tableName}_trigger_update_modified_at'
+) THEN
+	CREATE TRIGGER "${tableName}_trigger_update_modified_at"
+	BEFORE UPDATE ON "${tableName}"
+	FOR EACH ROW
+	EXECUTE PROCEDURE "trigger_update_modified_at"();
+END IF;
+END;
+$$`;
+
+describe('reference type', function () {
+	let test;
+	beforeEach(() => {
+		test = require('./test')(typeVocab);
+	});
+
+	it('informative - no foreignKey for reference field', async () => {
+		test(
+			`\
+
+Term:      term
+Term:      term history
+Fact Type: term history references term
+	Necessity: each term history references exactly one term
+	Reference Type: informative		
+`,
+			[
+				`\
+DO $$
+BEGIN
+	PERFORM '"trigger_update_modified_at"()'::regprocedure;
+EXCEPTION WHEN undefined_function THEN
+	CREATE FUNCTION "trigger_update_modified_at"()
+	RETURNS TRIGGER AS $fn$
+	BEGIN
+		NEW."modified at" = NOW();
+RETURN NEW;
+	END;
+	$fn$ LANGUAGE plpgsql;
+END;
+$$;`,
+
+				`\
+CREATE TABLE IF NOT EXISTS "term" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+);`,
+				modifiedAtTrigger('term'),
+				`\
+CREATE TABLE IF NOT EXISTS "term history" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+,	"references-term" INTEGER NOT NULL
+);`,
+				modifiedAtTrigger('term history'),
+			],
+		);
+	});
+
+	it('informative - no foreignKey for reference field - order of Reference Type and Rule is irrelevant ', function () {
+		test(
+			`\
+
+Term:      term
+Term:      term history
+Fact Type: term history references term
+	Reference Type: informative		
+	Necessity: each term history references exactly one term
+`,
+			[
+				`\
+DO $$
+BEGIN
+	PERFORM '"trigger_update_modified_at"()'::regprocedure;
+EXCEPTION WHEN undefined_function THEN
+	CREATE FUNCTION "trigger_update_modified_at"()
+	RETURNS TRIGGER AS $fn$
+	BEGIN
+		NEW."modified at" = NOW();
+RETURN NEW;
+	END;
+	$fn$ LANGUAGE plpgsql;
+END;
+$$;`,
+
+				`\
+CREATE TABLE IF NOT EXISTS "term" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+);`,
+				modifiedAtTrigger('term'),
+				`\
+CREATE TABLE IF NOT EXISTS "term history" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+,	"references-term" INTEGER NOT NULL
+);`,
+				modifiedAtTrigger('term history'),
+			],
+		);
+	});
+
+	it('strict - foreignKey for reference field', function () {
+		test(
+			`\
+Term: 		term
+Term: 		term history
+Fact Type: 	term history references term
+	Necessity:	each term history references exactly one term
+	Reference Type: strict
+`,
+			[
+				`\
+DO $$
+BEGIN
+	PERFORM '"trigger_update_modified_at"()'::regprocedure;
+EXCEPTION WHEN undefined_function THEN
+	CREATE FUNCTION "trigger_update_modified_at"()
+	RETURNS TRIGGER AS $fn$
+	BEGIN
+		NEW."modified at" = NOW();
+RETURN NEW;
+	END;
+	$fn$ LANGUAGE plpgsql;
+END;
+$$;`,
+
+				`\
+CREATE TABLE IF NOT EXISTS "term" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+);`,
+				modifiedAtTrigger('term'),
+				`\
+CREATE TABLE IF NOT EXISTS "term history" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+,	"references-term" INTEGER NOT NULL
+,	FOREIGN KEY ("references-term") REFERENCES "term" ("id")
+);`,
+				modifiedAtTrigger('term history'),
+			],
+		);
+	});
+
+	it('default (strict) - foreignKey for reference field', function () {
+		test(
+			`\
+Term: 		term
+Term: 		term history
+Fact Type: 	term history references term
+	Necessity:	each term history references exactly one term
+`,
+			[
+				`\
+DO $$
+BEGIN
+	PERFORM '"trigger_update_modified_at"()'::regprocedure;
+EXCEPTION WHEN undefined_function THEN
+	CREATE FUNCTION "trigger_update_modified_at"()
+	RETURNS TRIGGER AS $fn$
+	BEGIN
+		NEW."modified at" = NOW();
+RETURN NEW;
+	END;
+	$fn$ LANGUAGE plpgsql;
+END;
+$$;`,
+
+				`\
+CREATE TABLE IF NOT EXISTS "term" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+);`,
+				modifiedAtTrigger('term'),
+				`\
+CREATE TABLE IF NOT EXISTS "term history" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+,	"references-term" INTEGER NOT NULL
+,	FOREIGN KEY ("references-term") REFERENCES "term" ("id")
+);`,
+				modifiedAtTrigger('term history'),
+			],
+		);
+	});
+});


### PR DESCRIPTION
An informative reference is just an int field that points
to another tables id field - like foreign key without constraints
or foregein key cascades.

Change-type: minor
Signed-off-by: fisehara <harald@balena.io>