### PR TITLE
Avoid the operation type optimization for HAVING clauses

### DIFF
--- a/src/referenced-fields.ts
+++ b/src/referenced-fields.ts
@@ -174,6 +174,20 @@ const $getRuleReferencedFields = (
 				});
 			});
 			return;
+		case 'Having':
+			scope = { ...scope };
+			for (const key of Object.keys(scope)) {
+				// Treat all entries under a `HAVING` as unknown since it can include counts in such a way
+				// that our expectations of safety do not hold
+				scope[key] = { ...scope[key], isSafe: IsSafe.Unknown };
+			}
+			rulePart.forEach((node: AbstractSqlQuery) => {
+				$getRuleReferencedFields(referencedFields, node, isSafe, {
+					scope,
+					currentlyScopedAliases,
+				});
+			});
+			return;
 		case 'Count':
 			if (rulePart[1] !== '*') {
 				throw new Error(

--- a/test/abstract-sql/get-rule-referenced-fields.ts
+++ b/test/abstract-sql/get-rule-referenced-fields.ts
@@ -287,4 +287,25 @@ describe('getRuleReferencedFields', () => {
 			},
 		});
 	});
+
+	it('HAVING clauses should not be subject to the operation typecheck optimization', () => {
+		expect(
+			AbstractSqlCompiler.postgres.getRuleReferencedFields([
+				'NotExists',
+				[
+					'SelectQuery',
+					['Select', []],
+					['From', ['Table', 'test']],
+					['GroupBy', [['ReferencedField', 'test', 'field']]],
+					['Having', ['GreaterThanOrEqual', ['Count', '*'], ['Number', 2]]],
+				],
+			] as AbstractSqlCompiler.AbstractSqlQuery),
+		).to.deep.equal({
+			test: {
+				create: ['field', ''],
+				update: ['field', ''],
+				delete: [''],
+			},
+		});
+	});
 });


### PR DESCRIPTION
Since it's possible for them to behave in a way that violates the
safety checks we'll disable them until we can add specific checks
for the HAVING clause

Change-type: patch