### PR TITLE
Add `modifyFields`/`modifyName` to table definition

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -349,6 +349,8 @@ export interface AbstractSqlTable {
 	triggers?: Trigger[];
 	checks?: Check[];
 	definition?: Definition;
+	modifyFields?: AbstractSqlTable['fields'];
+	modifyName?: AbstractSqlTable['name'];
 }
 export interface SqlRule {
 	sql: string;


### PR DESCRIPTION
This is intended to be used to target tables differently for reads vs
writes, eg where you might read from a view/definition but want to
write to a physical table instead

Change-type: minor