### PR TITLE
Fix date fields used inside arithmetic expressions

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -89,12 +89,54 @@ export type NumberTypeNodes =
 	| CountNode
 	| AverageNode
 	| SumNode
+	| SubtractDateDateNode
 	| UnknownTypeNodes;
 
 export type FieldNode = ['Field', string];
 export type ReferencedFieldNode = ['ReferencedField', string, string];
 export type DateTruncNode = ['DateTrunc', TextTypeNodes, DateTypeNodes];
-export type DateTypeNodes = DateNode | DateTruncNode;
+export type DateTypeNodes =
+	| DateNode
+	| DateTruncNode
+	| SubtractDateNumberNode
+	| SubtractDateDurationNode
+	| AddDateTypeNodes;
+
+// Date operations return different types dependent on the operand types
+// here we explicitly type the different nodes by the input types
+// timestamp, datetime, date are use synonymous here and all are simplified under date node
+// returns integer
+export type SubtractDateDateNode = [
+	'SubtractDateDate',
+	DateTypeNodes,
+	DateTypeNodes,
+];
+// returns date
+export type SubtractDateNumberNode = [
+	'SubtractDateNumber',
+	DateTypeNodes,
+	NumberTypeNodes,
+];
+// returns date (timestamp)
+export type SubtractDateDurationNode = [
+	'SubtractDateDuration',
+	DateTypeNodes,
+	DurationNode,
+];
+export type AddDateTypeNodes = AddDateNumberNode | AddDateDurationNode;
+// returns date
+export type AddDateNumberNode = [
+	'AddDateNumber',
+	DateTypeNodes,
+	NumberTypeNodes,
+];
+// return date
+export type AddDateDurationNode = [
+	'AddDateDuration',
+	DateTypeNodes,
+	DurationNode,
+];
+
 export type BindNode = ['Bind', number | string] | ['Bind', string, string];
 export type CastNode = ['Cast', AbstractSqlType, string];
 export type CoalesceNode = [

--- a/src/AbstractSQLOptimiser.ts
+++ b/src/AbstractSQLOptimiser.ts
@@ -385,6 +385,17 @@ const JoinMatch =
 		}
 	};
 
+const AddDateMatcher = tryMatches(
+	matchArgs('AddDateDuration', DateValue, DurationValue),
+	matchArgs('AddDateNumber', DateValue, NumericValue),
+);
+
+const SubtractDateMatcher = tryMatches(
+	matchArgs('SubtractDateDate', DateValue, DateValue),
+	matchArgs('SubtractDateDuration', DateValue, DurationValue),
+	matchArgs('SubtractDateNumber', DateValue, NumericValue),
+);
+
 const typeRules: Dictionary<MatchFn> = {
 	UnionQuery: (args) => {
 		checkMinArgs('UnionQuery', args, 2);
@@ -632,8 +643,17 @@ const typeRules: Dictionary<MatchFn> = {
 		}),
 		matchArgs('IsDistinctFrom', AnyValue, AnyValue),
 	),
-	Add: MathOp('Add'),
-	Subtract: MathOp('Subtract'),
+	Add: tryMatches(MathOp('Add'), Helper(AddDateMatcher)),
+	Subtract: tryMatches(MathOp('Subtract'), Helper(SubtractDateMatcher)),
+	SubtractDateDate: matchArgs('SubtractDateDate', DateValue, DateValue),
+	SubtractDateNumber: matchArgs('SubtractDateNumber', DateValue, NumericValue),
+	SubtractDateDuration: matchArgs(
+		'SubtractDateDuration',
+		DateValue,
+		DurationValue,
+	),
+	AddDateDuration: matchArgs('AddDateDuration', DateValue, DurationValue),
+	AddDateNumber: matchArgs('AddDateNumber', DateValue, NumericValue),
 	Multiply: MathOp('Multiply'),
 	Divide: MathOp('Divide'),
 	Year: ExtractNumericDatePart('Year'),

--- a/test/abstract-sql/aggregate.ts
+++ b/test/abstract-sql/aggregate.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import { AbstractSqlQuery } from '../../src/AbstractSQLCompiler';
 
 type TestCb = (
@@ -36,6 +37,133 @@ describe('Sum', () => {
 		(result, sqlEquals) => {
 			it('should produce a valid SUM(5) statement', () => {
 				sqlEquals(result.query, 'SELECT SUM(5)');
+			});
+		},
+	);
+});
+
+describe('Subtract now timestamp from now timestamp', () => {
+	test(
+		['SelectQuery', ['Select', [['Subtract', ['Now'], ['Now']]]]],
+		(result, sqlEquals) => {
+			it('Subtract now timestamp from now timestamp', () => {
+				sqlEquals(result.query, 'SELECT CURRENT_TIMESTAMP - CURRENT_TIMESTAMP');
+			});
+		},
+	);
+});
+
+describe('Subtract Duration from now timestamp', () => {
+	test(
+		[
+			'SelectQuery',
+			['Select', [['Subtract', ['Now'], ['Duration', { day: 1 }]]]],
+		],
+		(result, sqlEquals) => {
+			it('Subtract Duration from now timestamp', () => {
+				sqlEquals(
+					result.query,
+					`SELECT CURRENT_TIMESTAMP - INTERVAL '1 0:0:0.0'`,
+				);
+			});
+		},
+	);
+});
+
+// this is not allowed
+describe('Add now timestamp to now timestamp should fail', () => {
+	test(
+		['SelectQuery', ['Select', [['Add', ['Now'], ['Now']]]]],
+		(result, sqlEquals) => {
+			it('Add now timestamp to now timestamp should fail', () => {
+				expect(result).to.be.empty;
+				expect(sqlEquals).to.be.undefined;
+				expect(result.query).to.not.eq(
+					'SELECT CURRENT_TIMESTAMP + CURRENT_TIMESTAMP',
+				);
+			});
+		},
+	);
+});
+
+describe('Add Duration to now timestamp', () => {
+	test(
+		['SelectQuery', ['Select', [['Add', ['Now'], ['Duration', { day: 1 }]]]]],
+		(result, sqlEquals) => {
+			it('Add Duration to now timestamp', () => {
+				sqlEquals(
+					result.query,
+					`SELECT CURRENT_TIMESTAMP + INTERVAL '1 0:0:0.0'`,
+				);
+			});
+		},
+	);
+});
+
+describe('Substract DateTrunc datefield from now timestamp', () => {
+	test(
+		[
+			'SelectQuery',
+			[
+				'Select',
+				[
+					[
+						'Subtract',
+						['Now'],
+						[
+							'DateTrunc',
+							['EmbeddedText', 'milliseconds'],
+							['Date', '2022-10-10'],
+						],
+					],
+				],
+			],
+		],
+		[['Date', '2022-10-10']],
+		(result, sqlEquals) => {
+			it('Substract DateTrunc datefield from now timestamp', () => {
+				sqlEquals(
+					result.query,
+					`SELECT CURRENT_TIMESTAMP - DATE_TRUNC('milliseconds', $1)`,
+				);
+			});
+		},
+	);
+});
+
+describe('Substract DateTrunc datefield from now timestamp', () => {
+	test(
+		[
+			'SelectQuery',
+			[
+				'Select',
+				[
+					[
+						'Subtract',
+						[
+							'DateTrunc',
+							['EmbeddedText', 'milliseconds'],
+							['Date', '2021-11-11'],
+						],
+						[
+							'DateTrunc',
+							['EmbeddedText', 'milliseconds'],
+							['Date', '2022-10-10'],
+						],
+					],
+				],
+			],
+		],
+		[
+			['Date', '2021-11-11'],
+			['Date', '2022-10-10'],
+		],
+		(result, sqlEquals) => {
+			it('Substract DateTrunc datefield from now timestamp', () => {
+				sqlEquals(
+					result.query,
+					`SELECT DATE_TRUNC('milliseconds', $1) - DATE_TRUNC('milliseconds', $2)`,
+				);
 			});
 		},
 	);


### PR DESCRIPTION
isNumericValue is evaluated in arithmetic expressions if operands in expression can be used as numericValues.

In SQL statements arithmetic expressions like add/sub are supported for date values.
DateArithmetic nodes need input dependent typing.

Change-type: minor
Signed-off-by: fisehara <harald@balena.io>