### PR TITLE
Dev: Replace husky with simple-git-hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,17 +32,15 @@
     "@types/mocha": "^10.0.0",
     "chai": "^4.3.7",
     "common-tags": "^1.8.2",
-    "husky": "^4.3.8",
     "lint-staged": "^13.0.3",
     "mocha": "^10.1.0",
     "require-npm4-to-publish": "^1.0.0",
+    "simple-git-hooks": "^2.8.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
+  "simple-git-hooks": {
+    "pre-commit": "npx lint-staged"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>

---

`husky` v5 and later caused a number of issues that caused the Jellyfish team to move to `simple-git-hooks` quite a while back. I don't remember the exact issue, but I believe it had something to do with hook installation. `simple-git-hooks` is quite simple as the name suggests and solves the problem without the extra headache.