### PR TITLE
Change AggregateJSON to use `JSON_AGG` instead of `ARRAY_TO_JSON`+`ARRAY_AGG`

### DIFF
--- a/src/AbstractSQLRules2SQL.ts
+++ b/src/AbstractSQLRules2SQL.ts
@@ -905,9 +905,7 @@ const typeRules: Dictionary<MatchFn> = {
 		if (typeof field !== 'string') {
 			throw new SyntaxError('`AggregateJSON` field must be a string');
 		}
-		return `COALESCE(ARRAY_TO_JSON(ARRAY_AGG("${table}".${escapeField(
-			field,
-		)})), '[]')`;
+		return `COALESCE(JSON_AGG("${table}".${escapeField(field)}), '[]')`;
 	},
 	Equals: Comparison('Equals'),
 	GreaterThan: Comparison('GreaterThan'),

--- a/test/odata/expand.js
+++ b/test/odata/expand.js
@@ -8,8 +8,7 @@ const {
 } = require('./fields');
 const _ = require('lodash');
 
-const postgresAgg = (field) =>
-	'COALESCE(ARRAY_TO_JSON(ARRAY_AGG(' + field + ")), '[]')";
+const postgresAgg = (field) => 'COALESCE(JSON_AGG(' + field + "), '[]')";
 const mysqlAgg = (field) => "'[' || group_concat(" + field + ", ',') || ']'";
 const websqlAgg = mysqlAgg;
 


### PR DESCRIPTION
This increases the minimum postgres version for AggregateJSON from 9.2 to 9.3 but it is likely that other places already require postgres
\>=9.3 and as such this should not increase the minimum version at all.
If it does somehow manage to then increasing the minimum from a 2012 postgres to 2013 should still be fine

Change-type: patch