### PR TITLE
Optimize schema during compilation

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -576,6 +576,8 @@ const compileSchema = (
 	engine: Engines,
 	ifNotExists: boolean,
 ): SqlModel => {
+	abstractSqlModel = optimizeSchema(abstractSqlModel, false);
+
 	let ifNotExistsStr = '';
 	let orReplaceStr = '';
 	if (ifNotExists) {

--- a/src/AbstractSQLSchemaOptimiser.ts
+++ b/src/AbstractSQLSchemaOptimiser.ts
@@ -34,6 +34,7 @@ const countFroms = (n: AbstractSqlType[]) => {
 
 export const optimizeSchema = (
 	abstractSqlModel: AbstractSqlModel,
+	createCheckConstraints: boolean = true,
 ): AbstractSqlModel => {
 	abstractSqlModel.rules = abstractSqlModel.rules
 		.map((rule): AbstractSqlQuery | undefined => {
@@ -65,6 +66,7 @@ export const optimizeSchema = (
 
 			const count = countFroms(ruleBody);
 			if (
+				createCheckConstraints &&
 				count === 1 &&
 				(ruleBody[0] === 'NotExists' ||
 					(ruleBody[0] === 'Equals' &&


### PR DESCRIPTION
This optimizes and normalizes rules before compiling the schema.

Change-type: minor
Signed-off-by: Carol Schulze <carol@balena.io>