### PR TITLE
Revert tightening of `OrderBy` to only field nodes

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -359,10 +359,7 @@ export type TableNode = ['Table', string];
 export type WhereNode = ['Where', BooleanTypeNodes];
 export type GroupByNode = ['GroupBy', Array<FieldNode | ReferencedFieldNode>];
 export type HavingNode = ['Having', BooleanTypeNodes];
-export type OrderByNode = [
-	'OrderBy',
-	...Array<['ASC' | 'DESC', FieldNode | ReferencedFieldNode]>,
-];
+export type OrderByNode = ['OrderBy', ...Array<['ASC' | 'DESC', AnyTypeNodes]>];
 export type LimitNode = ['Limit', NumberTypeNodes];
 export type OffsetNode = ['Offset', NumberTypeNodes];
 export type FieldsNode = ['Fields', string[]];

--- a/src/AbstractSQLOptimiser.ts
+++ b/src/AbstractSQLOptimiser.ts
@@ -606,7 +606,7 @@ const typeRules: Dictionary<MatchFn> = {
 				if (order !== 'ASC' && order !== 'DESC') {
 					throw new SyntaxError(`Can only order by "ASC" or "DESC"`);
 				}
-				const value = Field(getAbstractSqlQuery(arg, 1));
+				const value = AnyValue(getAbstractSqlQuery(arg, 1));
 				return [order, value];
 			}),
 		] as OrderByNode;


### PR DESCRIPTION
It can in fact be a lot of different things and that is now also reflected in the typing

Change-type: patch