### PR TITLE
Add `modelName` to AbstractSqlModel

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -521,6 +521,7 @@ export interface AbstractSqlModel {
 			[key: string]: LfRuleInfo;
 		};
 	};
+	modelName?: string;
 }
 export interface LfRuleInfo {
 	root: {


### PR DESCRIPTION
As abstractlSqlModel is used for a particular named model, the abstractSqlModel should carry this information itself. In particular this is needed for AbstractSqlQuery optimization that needs to be model translation aware.

Change-type: minor