### PR TITLE
Update `@balena/sbvr-types`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "repository": "https://github.com/balena-io-modules/abstract-sql-compiler.git",
   "author": "",
   "dependencies": {
-    "@balena/sbvr-types": "^6.0.0",
+    "@balena/sbvr-types": "^7.0.1",
     "lodash": "^4.17.21"
   },
   "devDependencies": {


### PR DESCRIPTION
Updaet @balena/sbvr-types from 6.0.0 to 7.0.1

@balena/sbvr-types changes `fetchProcessing` and not validate. No change in abstract-sql-compiler interfaces. => Patch

Change-type: patch