### PR TITLE
Clarify the `['Bind', string, string]` form of `BindNode` is legacy

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -233,7 +233,14 @@ export type CaseNode =
 	| ['Case', ...WhenNode[]]
 	| ['Case', ...WhenNode[], ElseNode];
 
-export type BindNode = ['Bind', number | string] | ['Bind', string, string];
+/**
+ * @deprecated This gets converted to the `['Bind', [string, string]]` form during compilation
+ */
+type BackCompatBindNode = ['Bind', string, string];
+export type BindNode =
+	| ['Bind', number | string]
+	| ['Bind', [string, string]]
+	| BackCompatBindNode;
 export type CastNode = ['Cast', AnyTypeNodes, string];
 export type CoalesceNode = [
 	'Coalesce',

--- a/src/AbstractSQLOptimiser.ts
+++ b/src/AbstractSQLOptimiser.ts
@@ -1195,15 +1195,21 @@ const typeRules = {
 			];
 		},
 	),
-	Bind: (args) => {
-		if (noBinds) {
-			throw new SyntaxError('Cannot use a bind whilst they are disabled');
-		}
-		if (args.length !== 1 && args.length !== 2) {
-			throw new SyntaxError(`"Bind" requires 1/2 arg(s)`);
-		}
-		return ['Bind', ...args] as BindNode;
-	},
+	Bind: tryMatches<BindNode>(
+		Helper<OptimisationMatchFn<BindNode>>((args) => {
+			if (args.length !== 2) {
+				return false;
+			}
+			return ['Bind', args] as BindNode;
+		}),
+		(args) => {
+			if (noBinds) {
+				throw new SyntaxError('Cannot use a bind whilst they are disabled');
+			}
+			checkArgs('Bind', args, 1);
+			return ['Bind', ...args] as BindNode;
+		},
+	),
 	Text,
 	Value: Text,
 	Date: matchArgs('Date', _.identity),

--- a/src/AbstractSQLRules2SQL.ts
+++ b/src/AbstractSQLRules2SQL.ts
@@ -1330,14 +1330,8 @@ const typeRules: Dictionary<MatchFn> = {
 		);
 	},
 	Bind: (args) => {
-		let bind;
-		if (args.length === 2) {
-			bind = args;
-		} else if (args.length === 1) {
-			bind = args[0];
-		} else {
-			throw new SyntaxError(`"Bind" requires 1/2 arg(s)`);
-		}
+		checkArgs('Bind', args, 1);
+		const bind = args[0];
 		return AddBind(['Bind', bind]);
 	},
 	Text,


### PR DESCRIPTION
Change-type: patch