### PR TITLE
Add optional time zone argument for DateTrunc

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -174,7 +174,9 @@ export type NumberTypeNodes = StrictNumberTypeNodes | UnknownTypeNodes;
 
 export type FieldNode = ['Field', string];
 export type ReferencedFieldNode = ['ReferencedField', string, string];
-export type DateTruncNode = ['DateTrunc', TextTypeNodes, DateTypeNodes];
+export type DateTruncNode =
+	| ['DateTrunc', TextTypeNodes, DateTypeNodes]
+	| ['DateTrunc', TextTypeNodes, DateTypeNodes, TextTypeNodes];
 export type ToDateNode = ['ToDate', DateTypeNodes];
 export type ToTimeNode = ['ToTime', DateTypeNodes];
 export type CurrentTimestampNode = ['CurrentTimestamp'];

--- a/src/AbstractSQLOptimiser.ts
+++ b/src/AbstractSQLOptimiser.ts
@@ -25,7 +25,6 @@ import type {
 	CrossJoinNode,
 	CurrentDateNode,
 	CurrentTimestampNode,
-	DateTruncNode,
 	DeleteQueryNode,
 	DivideNode,
 	DurationNode,
@@ -886,7 +885,16 @@ const typeRules = {
 	Floor: matchArgs<FloorNode>('Floor', NumericValue),
 	Ceiling: matchArgs<CeilingNode>('Ceiling', NumericValue),
 	ToDate: matchArgs<ToDateNode>('ToDate', DateValue),
-	DateTrunc: matchArgs<DateTruncNode>('DateTrunc', TextValue, DateValue),
+	DateTrunc: (args) => {
+		checkMinArgs('DateTrunc', args, 2);
+		const precision = TextValue(getAbstractSqlQuery(args, 0));
+		const date = DateValue(getAbstractSqlQuery(args, 1));
+		const timeZone =
+			args.length === 3 ? TextValue(getAbstractSqlQuery(args, 2)) : undefined;
+		return timeZone
+			? ['DateTrunc', precision, date, timeZone]
+			: ['DateTrunc', precision, date];
+	},
 	ToTime: matchArgs<ToTimeNode>('ToTime', DateValue),
 	ExtractJSONPathAsText: (args): ExtractJSONPathAsTextNode => {
 		checkMinArgs('ExtractJSONPathAsText', args, 1);

--- a/src/AbstractSQLRules2SQL.ts
+++ b/src/AbstractSQLRules2SQL.ts
@@ -1207,7 +1207,7 @@ const typeRules: Record<string, MatchFn> = {
 		return `DATE(${date})`;
 	},
 	DateTrunc: (args, indent) => {
-		checkArgs('DateTrunc', args, 2);
+		checkMinArgs('DateTrunc', args, 2);
 		const precision = TextValue(getAbstractSqlQuery(args, 0), indent);
 		const date = DateValue(getAbstractSqlQuery(args, 1), indent);
 		// Postgres generated timestamps have a microseconds precision
@@ -1215,7 +1215,13 @@ const typeRules: Record<string, MatchFn> = {
 		// js timestamps that have only milliseconds precision
 		// thus supporting for truncating to a given precision
 		if (engine === Engines.postgres) {
-			return `DATE_TRUNC(${precision}, ${date})`;
+			const timeZone =
+				args.length === 3
+					? TextValue(getAbstractSqlQuery(args, 2), indent)
+					: undefined;
+			return timeZone
+				? `DATE_TRUNC(${precision}, ${date}, ${timeZone})`
+				: `DATE_TRUNC(${precision}, ${date})`;
 		} else if (
 			// not postgresql ==> no need to truncate ==> return timestamp as is (milliseconds precision)
 			precision === "'milliseconds'" ||

--- a/test/abstract-sql/dates.ts
+++ b/test/abstract-sql/dates.ts
@@ -127,6 +127,29 @@ describe('DateTrunc', () => {
 			});
 		},
 	);
+
+	test(
+		[
+			'SelectQuery',
+			[
+				'Select',
+				[
+					[
+						'DateTrunc',
+						['EmbeddedText', 'year'],
+						['Date', '2022-10-10'],
+						['EmbeddedText', 'UTC'],
+					],
+				],
+			],
+		],
+		[['Date', '2022-10-10']],
+		(result, sqlEquals) => {
+			it('should produce a valid DateTrunc statement', () => {
+				sqlEquals(result, `SELECT DATE_TRUNC('year', $1, 'UTC')`);
+			});
+		},
+	);
 });
 
 describe('ToTime', () => {

--- a/test/odata/test.ts
+++ b/test/odata/test.ts
@@ -184,7 +184,6 @@ function runExpectation<ExpectFail extends boolean>(
 					0,
 				);
 				_.assign(body, extraBodyVars);
-				// @ts-expect-error - The tree returned by odata2AbstractSQL is typed using an older version of this module but works fine
 				result = AbstractSQLCompiler[engine].compileRule(tree);
 			} catch (e: any) {
 				if (!expectFailure) {


### PR DESCRIPTION
Change-type: minor

---

See: https://balena.fibery.io/Work/Project/Use-time-zone-based-timestamps-for-PineJS-dates-965