### PR TITLE
Treat `CaseNode` as an unknown type node as expected

### DIFF
--- a/src/AbstractSQLOptimiser.ts
+++ b/src/AbstractSQLOptimiser.ts
@@ -196,9 +196,6 @@ const tryMatches = <T extends AnyTypeNodes>(
 
 const AnyValue: MetaMatchFn<AnyTypeNodes> = (args) => {
 	const [type, ...rest] = args;
-	if (type === 'Case') {
-		return typeRules[type](rest);
-	}
 
 	for (const matcher of [
 		isJSONValue,
@@ -224,6 +221,7 @@ const UnknownValue: MetaMatchFn<UnknownTypeNodes> = (args) => {
 		case 'EqualsAny':
 		case 'Bind':
 		case 'Cast':
+		case 'Case':
 		case 'Coalesce':
 		case 'Any':
 			return typeRules[type](rest);

--- a/src/AbstractSQLRules2SQL.ts
+++ b/src/AbstractSQLRules2SQL.ts
@@ -53,9 +53,6 @@ const escapeField = (field: string | AbstractSqlQuery) =>
 
 const AnyValue: MetaMatchFn = (args, indent) => {
 	const [type, ...rest] = args;
-	if (type === 'Case') {
-		return typeRules[type](rest, indent);
-	}
 
 	for (const matcher of [
 		isJSONValue,
@@ -81,6 +78,7 @@ const UnknownValue: MetaMatchFn = (args, indent) => {
 		case 'EqualsAny':
 		case 'Bind':
 		case 'Cast':
+		case 'Case':
 		case 'Coalesce':
 		case 'ToJSON':
 		case 'Any':


### PR DESCRIPTION
This matches the fact that the result type is unknown/can be anything and also matches the existing typing

Change-type: minor