### PR TITLE
Switch to using a duplicate function exception to handle double function creation

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -780,14 +780,14 @@ const compileSchema = (
 			createSchemaStatements.push(`\
 DO $$
 BEGIN
-	PERFORM '"${fnName}"()'::regprocedure;
-EXCEPTION WHEN undefined_function THEN
 	CREATE FUNCTION "${fnName}"()
 	RETURNS TRIGGER AS $fn$
 	BEGIN
 		${fnDefinition.body}
 	END;
 	$fn$ LANGUAGE ${fnDefinition.language};
+EXCEPTION WHEN duplicate_function THEN
+	NULL;
 END;
 $$;`);
 			dropSchemaStatements.push(`DROP FUNCTION "${fnName}"();`);

--- a/test/sbvr/pilots.ts
+++ b/test/sbvr/pilots.ts
@@ -60,8 +60,6 @@ Fact type: licence was granted by pilot
 			`\
 DO $$
 BEGIN
-	PERFORM '"trigger_update_modified_at"()'::regprocedure;
-EXCEPTION WHEN undefined_function THEN
 	CREATE FUNCTION "trigger_update_modified_at"()
 	RETURNS TRIGGER AS $fn$
 	BEGIN
@@ -69,6 +67,8 @@ EXCEPTION WHEN undefined_function THEN
 RETURN NEW;
 	END;
 	$fn$ LANGUAGE plpgsql;
+EXCEPTION WHEN duplicate_function THEN
+	NULL;
 END;
 $$;`,
 			`\

--- a/test/sbvr/reference-type.ts
+++ b/test/sbvr/reference-type.ts
@@ -44,8 +44,6 @@ Fact Type: term history references term
 				`\
 DO $$
 BEGIN
-	PERFORM '"trigger_update_modified_at"()'::regprocedure;
-EXCEPTION WHEN undefined_function THEN
 	CREATE FUNCTION "trigger_update_modified_at"()
 	RETURNS TRIGGER AS $fn$
 	BEGIN
@@ -53,6 +51,8 @@ EXCEPTION WHEN undefined_function THEN
 RETURN NEW;
 	END;
 	$fn$ LANGUAGE plpgsql;
+EXCEPTION WHEN duplicate_function THEN
+	NULL;
 END;
 $$;`,
 
@@ -89,8 +89,6 @@ Fact Type: term history references term
 				`\
 DO $$
 BEGIN
-	PERFORM '"trigger_update_modified_at"()'::regprocedure;
-EXCEPTION WHEN undefined_function THEN
 	CREATE FUNCTION "trigger_update_modified_at"()
 	RETURNS TRIGGER AS $fn$
 	BEGIN
@@ -98,6 +96,8 @@ EXCEPTION WHEN undefined_function THEN
 RETURN NEW;
 	END;
 	$fn$ LANGUAGE plpgsql;
+EXCEPTION WHEN duplicate_function THEN
+	NULL;
 END;
 $$;`,
 
@@ -133,8 +133,6 @@ Fact Type: 	term history references term
 				`\
 DO $$
 BEGIN
-	PERFORM '"trigger_update_modified_at"()'::regprocedure;
-EXCEPTION WHEN undefined_function THEN
 	CREATE FUNCTION "trigger_update_modified_at"()
 	RETURNS TRIGGER AS $fn$
 	BEGIN
@@ -142,6 +140,8 @@ EXCEPTION WHEN undefined_function THEN
 RETURN NEW;
 	END;
 	$fn$ LANGUAGE plpgsql;
+EXCEPTION WHEN duplicate_function THEN
+	NULL;
 END;
 $$;`,
 
@@ -177,8 +177,6 @@ Fact Type: 	term history references term
 				`\
 DO $$
 BEGIN
-	PERFORM '"trigger_update_modified_at"()'::regprocedure;
-EXCEPTION WHEN undefined_function THEN
 	CREATE FUNCTION "trigger_update_modified_at"()
 	RETURNS TRIGGER AS $fn$
 	BEGIN
@@ -186,6 +184,8 @@ EXCEPTION WHEN undefined_function THEN
 RETURN NEW;
 	END;
 	$fn$ LANGUAGE plpgsql;
+EXCEPTION WHEN duplicate_function THEN
+	NULL;
 END;
 $$;`,
 


### PR DESCRIPTION
This should have slightly less edge cases than trying to execute the function and checking that it does not already exist, particularly if we add arguments or similar in future where the `PERFORM` command would need to match precisely

Change-type: patch