### PR TITLE
Allow sbvr-types v10 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "repository": "https://github.com/balena-io-modules/abstract-sql-compiler.git",
   "author": "",
   "peerDependencies": {
-    "@balena/sbvr-types": "^7.1.0 || ^8.0.0 || ^9.0.2"
+    "@balena/sbvr-types": "^7.1.0 || ^8.0.0 || ^9.0.2 || ^10.0.0"
   },
   "devDependencies": {
     "@balena/lf-to-abstract-sql": "^5.0.4",


### PR DESCRIPTION
See: https://balena.fibery.io/Work/Project/Make-release-assets-publicly-available-and-maintained-1177
Change-type: patch