### PR TITLE
Export an `optimizeSchema` variant that is database engine agnostic

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -1131,6 +1131,7 @@ const generateExport = (engine: Engines, ifNotExists: boolean) => {
 		getModifiedFields,
 	};
 };
+export { optimizeSchema };
 export const postgres = generateExport(Engines.postgres, true);
 export const mysql = generateExport(Engines.mysql, true);
 export const websql = generateExport(Engines.websql, false);


### PR DESCRIPTION
This can be used to optimize the schema without yet committing to a specific database engine, useful for a pass over abstractSql prior to generating a db engine specific sql model

Change-type: minor