### PR TITLE
Correctly treat `EqualsAnyNode` as the boolean type we know it to be

### DIFF
--- a/src/AbstractSQLCompiler.ts
+++ b/src/AbstractSQLCompiler.ts
@@ -254,7 +254,6 @@ export type UnknownTypeNodes =
 	| NullNode
 	| FieldNode
 	| ReferencedFieldNode
-	| EqualsAnyNode
 	| BindNode
 	| CastNode
 	| CaseNode

--- a/src/AbstractSQLOptimiser.ts
+++ b/src/AbstractSQLOptimiser.ts
@@ -218,7 +218,6 @@ const UnknownValue: MetaMatchFn<UnknownTypeNodes> = (args) => {
 		case 'Null':
 		case 'Field':
 		case 'ReferencedField':
-		case 'EqualsAny':
 		case 'Bind':
 		case 'Cast':
 		case 'Case':

--- a/src/AbstractSQLRules2SQL.ts
+++ b/src/AbstractSQLRules2SQL.ts
@@ -75,7 +75,6 @@ const UnknownValue: MetaMatchFn = (args, indent) => {
 		case 'Null':
 		case 'Field':
 		case 'ReferencedField':
-		case 'EqualsAny':
 		case 'Bind':
 		case 'Cast':
 		case 'Case':
@@ -175,7 +174,8 @@ export const isBooleanValue = (
 		type === 'Like' ||
 		type === 'IsNotDistinctFrom' ||
 		type === 'IsDistinctFrom' ||
-		type === 'StartsWith'
+		type === 'StartsWith' ||
+		type === 'EqualsAny'
 	);
 };
 const BooleanValue = MatchValue(isBooleanValue);

--- a/test/odata/test.ts
+++ b/test/odata/test.ts
@@ -184,6 +184,7 @@ function runExpectation<ExpectFail extends boolean>(
 					0,
 				);
 				_.assign(body, extraBodyVars);
+				// @ts-expect-error - The tree returned by odata2AbstractSQL is typed using an older version of this module but works fine
 				result = AbstractSQLCompiler[engine].compileRule(tree);
 			} catch (e: any) {
 				if (!expectFailure) {


### PR DESCRIPTION
Change-type: patch