### PR TITLE
Allow sbvr-types v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "repository": "https://github.com/balena-io-modules/abstract-sql-compiler.git",
   "author": "",
   "peerDependencies": {
-    "@balena/sbvr-types": "^7.1.0 || ^8.0.0 || ^9.0.2 || ^10.0.0"
+    "@balena/sbvr-types": "^7.1.0 || ^8.0.0 || ^9.0.2 || ^10.0.0 || ^11.0.0"
   },
   "devDependencies": {
     "@balena/lf-to-abstract-sql": "^5.0.4",


### PR DESCRIPTION
Change-type: patch

---

See: https://balena.fibery.io/Work/Project/Use-time-zone-based-timestamps-for-PineJS-dates-965
Allow for `sbvr-types` v11 for https://github.com/balena-io-modules/sbvr-types/pull/112